### PR TITLE
fix: rename api key env variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm test
 
       - name: Criar arquivo .env
-        run: echo "EXPO_PUBLIC_TMDB_KEY=${{ secrets.EXPO_PUBLIC_TMDB_KEY }}" > .env
+        run: echo "EXPO_PUBLIC_TMDB_API_KEY=${{ secrets.EXPO_PUBLIC_TMDB_API_KEY }}" > .env
 
       - name: Build para Web
         run: npx expo export --platform web --output-dir dist


### PR DESCRIPTION
alterei o nome da variavel de ambiente de EXPO_PUBLIC_TMDB_KEY para EXPO_PUBLIC_TMDB_API_KEY, pra ficar de acordo com o nome usado na chamada da API
